### PR TITLE
TraceOnlyErrorオプション

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,8 @@ jobs:
       - name: make lint-go
         run:  |
           # Explicitly set GOROOT to avoid golangci-lint/issues/3107
-          export GOROOT=$(go env GOROOT)
+          GOROOT=$(go env GOROOT)
+          export GOROOT
           make lint-go
 
   test:

--- a/factory.go
+++ b/factory.go
@@ -99,7 +99,8 @@ func (f *Factory) init() {
 
 		if f.options.Trace {
 			f.httpClient.Transport = &sacloudhttp.TracingRoundTripper{
-				Transport: f.httpClient.Transport,
+				Transport:       f.httpClient.Transport,
+				OutputOnlyError: f.options.TraceOnlyError,
 			}
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
-	github.com/sacloud/go-http v0.1.3
+	github.com/sacloud/go-http v0.1.4
 	github.com/sacloud/packages-go v0.0.7
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUD
 github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sacloud/go-http v0.1.3 h1:t+RADgwS5QgnMKlbggjwbXv01UEuXp0/9fV0xulYEeY=
-github.com/sacloud/go-http v0.1.3/go.mod h1:4LwFHG5N/599baV0JSuAQO5e3atHXx0Jb9322PrIoHo=
+github.com/sacloud/go-http v0.1.4 h1:Fdt2NsiwzHh+fDqJe2HTGqV6tWdSS4M2bSwevGccMp8=
+github.com/sacloud/go-http v0.1.4/go.mod h1:0pw+tgXhTdwq/hPVizyaTgpN1G/WUZHTWRdbMuU+o/Q=
 github.com/sacloud/packages-go v0.0.7 h1:Py6nksUuyoRBaHtPfpA9sTIxSKnQfce/xm7XkiCLZmQ=
 github.com/sacloud/packages-go v0.0.7/go.mod h1:NlADopH0g9pLGDHJLi1geDgQpZBN9w4Rl1ucvmiDwAI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/sacloud/api-client-go/profile"
 	sacloudhttp "github.com/sacloud/go-http"
@@ -59,6 +60,8 @@ type Options struct {
 
 	// Trace HTTPリクエスト/レスポンスのトレースログ(ダンプ)出力
 	Trace bool
+	// TraceOnlyError HTTPリクエスト/レスポンスのトレースログ(ダンプ)出力で非200番台のレスポンス時のみ出力する
+	TraceOnlyError bool
 
 	// RequestCustomizers リクエスト前に*http.Requestのカスタマイズを行うためのfunc
 	RequestCustomizers []sacloudhttp.RequestCustomizer
@@ -158,6 +161,9 @@ func MergeOptions(opts ...*Options) *Options {
 		if opt.Trace {
 			merged.Trace = true
 		}
+		if opt.TraceOnlyError {
+			merged.TraceOnlyError = true
+		}
 		if len(opt.RequestCustomizers) > 0 {
 			merged.RequestCustomizers = opt.RequestCustomizers
 		}
@@ -187,7 +193,8 @@ func OptionsFromEnv() *Options {
 		RetryWaitMax: envvar.IntFromEnv("SAKURACLOUD_RETRY_WAIT_MAX", 0),
 		RetryWaitMin: envvar.IntFromEnv("SAKURACLOUD_RETRY_WAIT_MIN", 0),
 
-		Trace: envvar.StringFromEnv("SAKURACLOUD_TRACE", "") != "",
+		Trace:          envvar.StringFromEnv("SAKURACLOUD_TRACE", "") != "",
+		TraceOnlyError: strings.ToLower(envvar.StringFromEnv("SAKURACLOUD_TRACE", "")) == "error",
 	}
 }
 
@@ -225,7 +232,7 @@ func OptionsFromProfile(profileName string) (*Options, error) {
 		RetryWaitMax:         config.RetryWaitMax,
 		RetryWaitMin:         config.RetryWaitMin,
 		Trace:                config.EnableHTTPTrace(),
-
-		profileConfigValue: &config,
+		TraceOnlyError:       strings.ToLower(config.TraceMode) == "error",
+		profileConfigValue:   &config,
 	}, nil
 }


### PR DESCRIPTION
- TraceOnlyErrorオプション(bool型)を追加
  - Traceがtrueの場合のみ有効
- 環境変数からこのオプションを指定する場合、`SAKURACLOUD_TRACE`に`error`(ケースインセンシティブ)が指定されていたら有効になる