### PR TITLE
Improve APIError related functions

### DIFF
--- a/error.go
+++ b/error.go
@@ -28,11 +28,29 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("API Error %d - %s: %s", e.Code, e.Message, e.Err.Error())
+	if e.Err == nil {
+		return fmt.Sprintf("API Error %d - %s", e.Code, e.Message)
+	} else {
+		return fmt.Sprintf("API Error %d - %s: %s", e.Code, e.Message, e.Err.Error())
+	}
 }
 
 func (e *APIError) Unwrap() error {
 	return e.Err
+}
+
+func NewAPIError(code int, msg string, err error) *APIError {
+	if len(msg) == 0 {
+		msg = http.StatusText(code)
+		if msg == "" { // client uses 0 for unknown error
+			msg = "unknown error"
+		}
+	}
+	return &APIError{
+		Code:    code,
+		Message: msg,
+		Err:     err,
+	}
 }
 
 func IsNotFoundError(err error) bool {

--- a/error_test.go
+++ b/error_test.go
@@ -24,7 +24,7 @@ func (e *XXXAPIError) Unwrap() error {
 	return e.Err
 }
 
-func TestAPIError_Error(t *testing.T) {
+func TestAPIError(t *testing.T) {
 	err := &client.APIError{
 		Code:    http.StatusNotFound,
 		Message: "not found",
@@ -35,9 +35,15 @@ func TestAPIError_Error(t *testing.T) {
 
 	// Unwrap
 	assert.Equal(t, "wrapped error", errors.Unwrap(err).Error())
+
+	err2 := client.NewAPIError(http.StatusBadRequest, "", nil)
+	require.Equal(t, "API Error 400 - Bad Request", err2.Error())
+	assert.False(t, client.IsNotFoundError(err2))
 }
 
 func TestXXXAPIError_IsNotFoundError(t *testing.T) {
+	// Test with wrapped APIError
+
 	assert.False(t, client.IsNotFoundError(nil))
 
 	xerr := &XXXAPIError{


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No isue

### このPRはどういう変更を行いますか？

https://github.com/sacloud/api-client-go/pull/72 を他のクライアントで試したところももう少し機能が欲しかったので追加。
APIErrorを作るヘルパー関数や、`Error()`でerrorがnilの場合のケースを追加。

### ドキュメントの変更は必要ですか？

必要無し。